### PR TITLE
Branch for version 30: Rebase on master

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,20 @@
 {% set name = "ngspice" %}
-{% set version = "32" %}
+{% set version = "30" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://ayera.dl.sourceforge.net/project/ngspice/ng-spice-rework/{{ version }}/ngspice-{{ version }}.tar.gz
-  sha256: 3cd90c4e94516d87c5b4d02a3a6405b1136b25d05c871d4fee1fd7c4c0d03ef2
+  url: https://svwh.dl.sourceforge.net/project/ngspice/ng-spice-rework/{{ version }}/ngspice-{{ version }}.tar.gz
+  sha256: 08fe0e2f3768059411328a33e736df441d7e6e7304f8dad0ed5f28e15d936097
 
   patches:
    - patches/libtoolize-name.patch  # [osx]
    - patches/vngspice-install-location.patch  # [win]
 
 build:
-  number: 4
+  number: 1
   skip: True  # [win and vc<14]
 
 # Due to how 'conda render' extracts metadata info, the 'outputs'


### PR DESCRIPTION
This is a PR to the branch for version 30, not the master branch, which currently builds version 32.

This PR brings the feedstock up-to-date with the latest changes in the master branch, including separate outputs for `ngspice-lib` and `ngspice-exe`, windows support, and various fixes.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy`
    - re-rendering yielded no changes

