### PR TITLE
Version 30: Force identical builds of ngspice, ngspice-lib, ngspice-exe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
    - patches/vngspice-install-location.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
   # Apparently the .sln or .vcproj file for version 30 is not the same as the one for version 32,
   # so the Windows build errors out with:
@@ -102,8 +102,8 @@ outputs:
   - name: ngspice
     requirements:
       run:
-        - {{ pin_subpackage('ngspice-lib', max_pin="x.x.x.x") }}
-        - {{ pin_subpackage('ngspice-exe', max_pin="x.x.x.x") }}
+        - {{ pin_subpackage('ngspice-lib', exact=True) }}
+        - {{ pin_subpackage('ngspice-exe', exact=True) }}
 
     test:
       commands:
@@ -153,8 +153,8 @@ outputs:
   - name: ngspice
     requirements:
       run:
-        - {{ pin_subpackage('ngspice-lib', max_pin="x.x.x.x") }}
-        - {{ pin_subpackage('ngspice-exe', max_pin="x.x.x.x") }}
+        - {{ pin_subpackage('ngspice-lib', exact=True) }}
+        - {{ pin_subpackage('ngspice-exe', exact=True) }}
 
     test:
       commands:


### PR DESCRIPTION
This is a PR onto the version 30 maintenance branch
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
